### PR TITLE
👷 (travis): limit clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js: lts/*
 
+git:
+  depth: 2
+
 cache: yarn
 
 before_script:


### PR DESCRIPTION
a depth of 1 disables queue functionality according to the docs, so set clone depth to 2 instead.