### PR TITLE
🔧 (drone): ignore failing publish step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,7 @@ steps:
       - yarn run build
 
   - name: publish
+    failure: ignore
     image: plugins/gh-pages
     settings:
       pages_directory: dist/


### PR DESCRIPTION
the github token isn't revealed to PR builds, so it fails automatically